### PR TITLE
Remove es-toolkit dependency

### DIFF
--- a/.changeset/moody-ears-train.md
+++ b/.changeset/moody-ears-train.md
@@ -1,0 +1,5 @@
+---
+"@valtown/ls-ws-server": patch
+---
+
+Remove unused es-toolkit dependency

--- a/ls-ws-server/package.json
+++ b/ls-ws-server/package.json
@@ -72,7 +72,6 @@
   "main": "./dist/index.js",
   "type": "module",
   "dependencies": {
-    "es-toolkit": "^1.39.8",
     "execa": "^9.6.0",
     "isows": "^1.0.7",
     "json-rpc-2.0": "^1.7.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
     },
     "codemirror-ls": {
       "name": "@valtown/codemirror-ls",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "ISC",
       "dependencies": {
         "p-queue": "^8.1.0",
@@ -141,7 +141,6 @@
       "version": "0.0.24",
       "license": "ISC",
       "dependencies": {
-        "es-toolkit": "^1.39.8",
         "execa": "^9.6.0",
         "isows": "^1.0.7",
         "json-rpc-2.0": "^1.7.1",


### PR DESCRIPTION
This dependency was not used. There are other unused dependencies which can be identified with knip but at least removing this is a start.