### PR TITLE
Add changeset, adopt OIDC

### DIFF
--- a/.changeset/eighty-maps-give.md
+++ b/.changeset/eighty-maps-give.md
@@ -1,0 +1,6 @@
+---
+"@valtown/codemirror-ls": patch
+"@valtown/ls-ws-server": patch
+---
+
+Adopt OIDC for publishing

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,5 +34,3 @@ jobs:
           publish: npx @changesets/cli publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Doing our part for supply-chain attack safety: adopting OIDC in place of NPM tokens.